### PR TITLE
server-api: Initial MONAID Server API

### DIFF
--- a/server-api/grpc/common.proto
+++ b/server-api/grpc/common.proto
@@ -1,0 +1,88 @@
+syntax  = "proto3";
+
+package monai.platform;
+
+option csharp_namespace = "Monai.Deploy.Server.Grpc";
+option go_package = "apis";
+option java_package = "com.monai.depoly.server.grpc";
+
+import public "response-code.proto";
+
+// 128-bit unique identifier (UUID).
+message Identifier {
+  // Expected to be an array of 16 bytes.
+  bytes data = 1;
+}
+
+message HistoricalEvent {
+  // Timestamp of when the event occurred.
+  Timestamp timestamp = 1;
+
+  // Unique identifier of the user who caused the event.
+  // No value is provided when the event was the result of a non-user action.
+  Identifier user_id = 2;
+
+  // Description of the event.
+  // Maximum allowed size for an event description is 4096 bytes (4 KiB).
+  string description = 3;
+}
+
+// Version information structure.
+message Version {
+  // Version for incompatible API changes.
+  int32 major = 1;
+
+  // Version for added functionality in a backwards compatible manner.
+  int32 minor = 2;
+
+  // Version for backwards compatible bug fixes.
+  int32 patch = 3;
+
+  // Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+  // Maximum allowed size of a version label is 128 bytes.
+  string label = 4;
+}
+
+// Standard header expected to be attached to all requests.
+message RequestHeader {
+  // Version of the API expected to handle the request.
+  Version api_version = 1;
+
+  // Name of the agent interacting with the server.
+  // Maxium allowed size for a user-agent is 512 bytes.
+  string user_agent = 2;
+
+  // Authentication header for the request.
+  // Maximum allowed size is 14360576 bytes (1 MiB).
+  string authentication = 3;
+}
+
+// Return value of most API calls, specifies success or failure.
+message ResponseHeader {
+  // Version of the API which handled the request.
+  Version api_version = 1;
+
+  // The name / identifier of the server.
+  // Maximum allowed size of the server identier is 512 bytes.
+  string server = 2;
+
+  // The response or "error" code of the request.
+  // Zero (0) indicates the request was successful.
+  ErrorCode code = 3;
+
+  // When returned, URI the client can use to authenticate itself.
+  string authenticateUri = 4;
+
+  // When returned, URI the client can use to get more information.
+  string redirectUri = 5;
+
+  // Optional message(s) returned with the result.
+  // Maximum allowed size is 262144 bytes (256 KiB) per message, and 2097152 bytes (2 MiB) total.
+  repeated string messages = 6;
+}
+
+// Timestamp type
+message Timestamp {
+  // The number of milliseconds before or after 0001-01-01 00:00:00.000Z.
+  sint64 value = 1;
+}

--- a/server-api/grpc/common.proto
+++ b/server-api/grpc/common.proto
@@ -1,12 +1,12 @@
 syntax  = "proto3";
 
-package monai.platform;
+package monai.deploy.platform;
 
-option csharp_namespace = "Monai.Deploy.Server.Grpc";
-option go_package = "apis";
-option java_package = "com.monai.depoly.server.grpc";
+option csharp_namespace = "Monai.Deploy.Platform.Grpc";
+option go_package = "monaid.grpc";
+option java_package = "com.monai.depoly.platform.grpc";
 
-import public "response-code.proto";
+import public "error-code.proto";
 
 // 128-bit unique identifier (UUID).
 message Identifier {

--- a/server-api/grpc/error-code.proto
+++ b/server-api/grpc/error-code.proto
@@ -32,7 +32,7 @@ enum ErrorCode {
     ERROR_AUTHORITY_UNAVAILABLE = 2001;
     // Kubernetes is unvailable.
     ERROR_CLUSTER_UNAVAILABLE = 2002;
-    // Database is unavailable.
+    // Database is unavailble.
     ERROR_DATABASE_UNAVAILABLE = 2003;
     // Network is unavailable.
     ERROR_NETWORK_UNAVAILABLE = 2004;
@@ -56,7 +56,7 @@ enum ErrorCode {
     // Provided job identifier is not associated with any known job.
     ERROR_JOB_ID_UNKNOWN = 4005;
     // Request job logs are currently unavailable.
-    ERROR_JOB_LOGS_UNAVAILABLE = 4006;
+    ERROR_JOB_LOGS_UNAVAILBLE = 4006;
     // Provided job-priority is invalid.
     ERROR_JOB_PRIORITY_INVALID = 4007;
     // Provided job-state is invalid.
@@ -120,7 +120,7 @@ enum ErrorCode {
     // Provided payload reference name is not associated with any known payload.
     ERROR_PAYLOAD_NAME_UNKNOWN = 6013;
     // Requested payload is unavailable.
-    ERROR_PAYLOAD_UNAVAILABLE = 6014;
+    ERROR_PAYLOAD_UNAVAILBLE = 6014;
 
     // Generic user error occurred.
     ERROR_USER = 7001;

--- a/server-api/grpc/error-code.proto
+++ b/server-api/grpc/error-code.proto
@@ -1,0 +1,129 @@
+syntax = "proto3";
+
+package monai.deploy.server;
+
+option csharp_namespace = "Monai.Deploy.Server.Grpc";
+option go_package = "apis";
+option java_package = "com.monai.deploy.server.grpc";
+
+enum ErrorCode {
+    // Request was successful.
+    ERROR_SUCCESS = 0;
+
+    // Request was malformed, or otherwise invalid.
+    ERROR_BAD_REQUEST = 1;
+    // Request authoriztion was malformed.
+    ERROR_AUTHORIZATION_INVALID = 2;
+    // Request user-agent was malformed.
+    ERROR_USER_AGENT_INVALID = 3;
+    // Request api-version was malformed.
+    ERROR_VERSION_INVALID = 4;
+    // Request api-version is unsupported.
+    ERROR_VERSION_UNSUPPORTED = 5;
+
+    // General authentication error occurred.
+    ERROR_AUTHENTICATION = 1001;
+    // Request is unauthorized.
+    ERROR_UNAUTHORIZED = 1002;
+    // User lacks sufficient privileges.
+    ERROR_UNPRIVILEGED = 1003;
+
+    // Authority is unavaialble.
+    ERROR_AUTHORITY_UNAVAILABLE = 2001;
+    // Kubernetes is unvailable.
+    ERROR_CLUSTER_UNAVAILABLE = 2002;
+    // Database is unavailble.
+    ERROR_DATABASE_UNAVAILABLE = 2003;
+    // Network is unavailable.
+    ERROR_NETWORK_UNAVAILABLE = 2004;
+    // Storage is unavailable or exhausted.
+    ERROR_STORAGE_UNAVAILABLE = 2005;
+    // Request timed out.
+    ERROR_REQUEST_TIMED_OUT = 2006;
+    // General internal error occurred.
+    ERROR_UNHANDLED = 2007;
+
+    // Generic job error occured.
+    ERROR_JOB = 4001;
+    // Job has been cancelled.
+    // Cannot cancel a job more than once.
+    // Cannot download from a cancelled job.
+    ERROR_JOB_CANCELED = 4002;
+    // Requested job has been deleted.
+    ERROR_JOB_DELETED = 4003;
+    // Provided job identifier is invalid.
+    ERROR_JOB_ID_INVALID = 4004;
+    // Provided job identifier is not associated with any known job.
+    ERROR_JOB_ID_UNKNOWN = 4005;
+    // Request job logs are currently unavailable.
+    ERROR_JOB_LOGS_UNAVAILBLE = 4006;
+    // Provided job-priority is invalid.
+    ERROR_JOB_PRIORITY_INVALID = 4007;
+    // Provided job-state is invalid.
+    ERROR_JOB_STATE_INVALID = 4008;
+    // Requested job has already stopped and cannot be cancelled.
+    ERROR_JOB_STOPPED = 4009;
+    // Requested job is unavailable.
+    ERROR_JOB_UNAVAILABLE = 4010;
+
+    // Generic MAP error occurred.
+    ERROR_MAP = 5001;
+    // Requested MAP has been deleted.
+    ERROR_MAP_DELETED = 5002;
+    // Provided MAP identifier is invalid.
+    ERROR_MAP_ID_INVALID = 5003;
+    // Provided MAP identifier is not assocaiated with any known MAP.
+    ERROR_MAP_ID_UNKNOWN = 5004;
+    // Provided MAP reference name already exists.
+    // If the intent is to move the reference name to the new MAP, set take_reference_name = true.
+    ERROR_MAP_NAME_DUPLICATE = 5005;
+    // Provided MAP reference name is invalid.
+    ERROR_MAP_NAME_INVALID = 5006;
+    // Provided MAP reference name is not associated with any known MAP.
+    ERROR_MAP_NAME_UNKNOWN = 5007;
+    // Provided MAP state is invalid.
+    ERROR_MAP_STATE_INVALID = 5008;
+    // Provided MAP URN is already associated with a known MAP.
+    ERROR_MAP_URN_DUPLICATE = 5009;
+    // Provided MAP URN is invalid.
+    ERROR_MAP_URN_INVALID = 5010;
+    // Requested MAP is unavailable.
+    ERROR_MAP_UNAVAILABLE = 5011;
+
+    ERROR_PAYLOAD = 6001;
+    // Requested payload has been deleted.
+    ERROR_PAYLOAD_DELETED = 6002;
+    // Payloads associated with pending or running jobs, or which have reference names cannot be deleted.
+    ERROR_PAYLOAD_IN_USE = 6003;
+    // Provided blob path is invalid.
+    ERROR_PAYLOAD_BLOB_PATH_INVALID = 6004;
+    // Provided blob path is not associated with any known payload blob.
+    ERROR_PAYLOAD_BLOB_PATH_UNKNOWN = 6005;
+    // Provided blob mode is invalid.
+    ERROR_PAYLOAD_BLOB_MODE_INVALID = 6006;
+    // Creation of empty payload blobs is not supported.
+    ERROR_PAYLOAB_BLOB_EMPTY = 6007;
+    // Provided payload identifier is invalid.
+    ERROR_PAYLOAD_ID_INVALID = 6008;
+    // Provided payload identifier is not assocaiated with any known payload.
+    ERROR_PAYLOAD_ID_UNKNOWN = 6009;
+    // Payloads associated with pending, running, or completed jobs cannot be modified.
+    // Blobs cannot be added or removed from the payload.
+    ERROR_PAYLOAD_IMMUTABLE = 6010;
+    // Provided payload reference name already exists.
+    // If the intent is to move the reference name to the new MAP, set take_reference_name = true.
+    ERROR_PAYLOAD_NAME_DUPLICATE = 6011;
+    // Provided payload reference name is invalid.
+    ERROR_PAYLOAD_NAME_INVALID = 6012;
+    // Provided payload reference name is not associated with any known payload.
+    ERROR_PAYLOAD_NAME_UNKNOWN = 6013;
+    // Requested payload is unavailable.
+    ERROR_PAYLOAD_UNAVAILBLE = 6014;
+
+    // Generic user error occurred.
+    ERROR_USER = 7001;
+    // Provided user identifier is invalid.
+    ERROR_USER_ID_INVALID = 7002;
+    // Provided user identifer not associated with any known user.
+    ERROR_USER_ID_UNKNOWN = 7003;
+}

--- a/server-api/grpc/error-code.proto
+++ b/server-api/grpc/error-code.proto
@@ -63,8 +63,10 @@ enum ErrorCode {
     ERROR_JOB_STATE_INVALID = 4008;
     // Requested job has already stopped and cannot be cancelled.
     ERROR_JOB_STOPPED = 4009;
+    // Unable to create job due to insufficient available resources.
+    ERROR_JOB_UNSCHEDULABLE = 4010;
     // Requested job is unavailable.
-    ERROR_JOB_UNAVAILABLE = 4010;
+    ERROR_JOB_UNAVAILABLE = 4011;
 
     // Generic MAP error occurred.
     ERROR_MAP = 5001;

--- a/server-api/grpc/error-code.proto
+++ b/server-api/grpc/error-code.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package monai.deploy.server;
+package monai.deploy.platform;
 
-option csharp_namespace = "Monai.Deploy.Server.Grpc";
-option go_package = "apis";
-option java_package = "com.monai.deploy.server.grpc";
+option csharp_namespace = "Monai.Deploy.Platform.Grpc";
+option go_package = "monaid.grpc";
+option java_package = "com.monai.deploy.platform.grpc";
 
 enum ErrorCode {
     // Request was successful.
@@ -32,7 +32,7 @@ enum ErrorCode {
     ERROR_AUTHORITY_UNAVAILABLE = 2001;
     // Kubernetes is unvailable.
     ERROR_CLUSTER_UNAVAILABLE = 2002;
-    // Database is unavailble.
+    // Database is unavailable.
     ERROR_DATABASE_UNAVAILABLE = 2003;
     // Network is unavailable.
     ERROR_NETWORK_UNAVAILABLE = 2004;
@@ -56,7 +56,7 @@ enum ErrorCode {
     // Provided job identifier is not associated with any known job.
     ERROR_JOB_ID_UNKNOWN = 4005;
     // Request job logs are currently unavailable.
-    ERROR_JOB_LOGS_UNAVAILBLE = 4006;
+    ERROR_JOB_LOGS_UNAVAILABLE = 4006;
     // Provided job-priority is invalid.
     ERROR_JOB_PRIORITY_INVALID = 4007;
     // Provided job-state is invalid.
@@ -120,7 +120,7 @@ enum ErrorCode {
     // Provided payload reference name is not associated with any known payload.
     ERROR_PAYLOAD_NAME_UNKNOWN = 6013;
     // Requested payload is unavailable.
-    ERROR_PAYLOAD_UNAVAILBLE = 6014;
+    ERROR_PAYLOAD_UNAVAILABLE = 6014;
 
     // Generic user error occurred.
     ERROR_USER = 7001;

--- a/server-api/grpc/job.proto
+++ b/server-api/grpc/job.proto
@@ -35,7 +35,7 @@ service Job {
   rpc List(JobListRequest) returns (stream JobListResponse);
 
   // Requests the status of a known job.
-  rpc Status(JobDetailsRequest) returns (JobDetailsResponse);
+  rpc Status(JobStatusRequest) returns (JobStatusResponse);
 }
 
 // The relative priority of a job.

--- a/server-api/grpc/job.proto
+++ b/server-api/grpc/job.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package monai.deploy.server;
+package monai.deploy.platform;
 
-option csharp_namespace = "Monai.Deploy.Server.Grpc";
-option go_package = "apis";
-option java_package = "com.monai.deploy.server.grpc";
+option csharp_namespace = "Monai.Deploy.Platform.Grpc";
+option go_package = "monaid.grpc";
+option java_package = "com.monai.deploy.platform.grpc";
 
 import public "common.proto";
 
@@ -93,7 +93,7 @@ enum JobState {
   // The job completed successfully.
   JOB_STATE_SUCCESS = 5;
 
-  // The job encountered a terminal error.
+  // The job encountered a terminal error, and is no longer running.
   JOB_STATE_FAILURE = 6;
 
   // The job was stopped, before it could complete, by user/external request.
@@ -109,7 +109,7 @@ enum JobState {
   JOB_STATE_TIMEOUT = 11;
 
   // The job cannot be scheduled due the requried MAP being unavailable.
-  JOB_STATE_NOTREADY = 12;
+  JOB_STATE_NOT_READY = 12;
 
   // The job faulted due to an out of memory condition.
   // This generally happens when requested memory is insufficient for the application.
@@ -198,7 +198,26 @@ message JobDeleteRequest {
   Identifier job_id = 2;
 }
 
+// Response from Job::Delete rpc.
 message JobDeleteResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the job.
+  Identifier job_id = 2;
+}
+
+// Request for Job::Finalize rpc.
+message JobFinalizeRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Unique identifer of the job to delete.
+  Identifier job_id = 2;
+}
+
+// Response from Job::Finalize rpc.
+message JobFinalizeResponse {
   // Standard RPC response header.
   ResponseHeader header = 1;
 
@@ -314,7 +333,7 @@ message JobStatusRequest {
   bool include_logs = 4;
 
   // When true, the history of the job is returned; otherwise history is not returned.
-  bool include_history = 4;
+  bool include_history = 5;
 }
 
 // Response from Job::Status rpc.

--- a/server-api/grpc/job.proto
+++ b/server-api/grpc/job.proto
@@ -1,0 +1,379 @@
+syntax = "proto3";
+
+package monai.deploy.server;
+
+option csharp_namespace = "Monai.Deploy.Server.Grpc";
+option go_package = "apis";
+option java_package = "com.monai.deploy.server.grpc";
+
+import public "common.proto";
+
+// Service for managing jobs.
+service Job {
+  // Requests the cancellation of a job.
+  // Job cancellation takes place asynchronously after the request-response has completed.
+  // Attempting to cancel a completed, cancelled, or deleted job will result in an error.
+  rpc Cancel(JobCancelRequest) returns (JobCancelResponse);
+
+  // Requests creation of a new job using a specified MAP and payload.
+  // Attempting to create a job with a deleted or error-state MAP will result in an error.
+  // Attempting to create a job with a deleted payload will result in an error.
+  rpc Create(JobCreateRequest) returns (JobCreateResponse);
+
+  // Requests deletion of a job.
+  // Deleted jobs are finalized, if not already finalized, and not returned by Job::List by default.
+  rpc Delete(JobDeleteRequest) returns (JobDeleteResponse);
+
+  // Requests the finalization of a job, signaling that any associated payloads are available for garbage collection.
+  // Requesting to finalize a pending or running job will result in an error.
+  // Requesting to finalize an already finalized job will result in an error.
+  rpc Finalize(JobFinalizeRequest) returns (JobFinalizeResponse);
+
+  // Requests a filtered list of known jobs.
+  // When no filter is provided, the default filter will be used.
+  // Deleted jobs are not returned unless requested.
+  rpc List(JobListRequest) returns (stream JobListResponse);
+
+  // Requests the status of a known job.
+  rpc Status(JobDetailsRequest) returns (JobDetailsResponse);
+}
+
+// The relative priority of a job.
+// Jobs with normal, lower, or higher priorites are queued and run as soon as resources are available.
+// Jobs with immediate priority are started immediately, if resources are available.
+enum JobPriority {
+  // The job priority is unknown.
+  JOB_PRIORITY_UNKNOWN = 0;
+
+/** Feature Not Available in Current Version
+ * The job prioritization feature, which requires that the server support queuing and scheduling
+ * will not be available in version 0.
+ *
+ * // The job priority is lower than normal.
+ * // Lower priority jobs are queued like higher priority jobs.
+ * // Lower priority jobs are scheduled for execution less frequently than higher priority jobs.
+ * JOB_PRIORITY_LOWER = 1;
+ *
+ * // The job priority is normal, the default priority for new jobs.
+ * JOB_PRIORITY_NORMAL = 2;
+ *
+ * // The job priority is higher than normal.
+ * // Higher priority jobs are queued like lower priority jobs.
+ * // Higher priority jobs are scheduled for execution more frequently than lower priority jobs.
+ * JOB_PRIORITY_HIGHER = 3;
+**/
+
+  // Immediate priority jobs are started immediately, if resources are available.
+  // When a job cannot be started immediately, an error code will be returned.
+  JOB_PRIORITY_IMMEDIATE = 4;
+}
+
+// The state of a job.
+enum JobState {
+  // The job is unknown or in an unknown state.
+  JOB_STATE_UNKNOWN = 0;
+
+  // The job has been created, but not yet started.
+  // Healthy state progression is from created to pending.
+  JOB_STATE_CREATED = 1;
+
+  // The job has been 'started' and queued waiting for resources.
+  // Healthy state progression is from pending to starting.
+  JOB_STATE_PENDING = 2;
+
+  // The job is starting.
+  // Starting includes resource allocation and container/pod scheduling.
+  // Healthy state progression is from starting to running.
+  JOB_STATE_STARTING = 3;
+
+  // The job is currently running.
+  // Healthy state progression is from running to success.
+  JOB_STATE_RUNNING = 4;
+
+  // The job completed successfully.
+  JOB_STATE_SUCCESS = 5;
+
+  // The job encountered a terminal error.
+  JOB_STATE_FAILURE = 6;
+
+  // The job was stopped, before it could complete, by user/external request.
+  JOB_STATE_CANCELED = 7;
+
+  // The job cannot be scheduled due to insufficient resources.
+  JOB_STATE_STARVED = 8;
+
+  // The job was evicted, before it could complete, by the server.
+  JOB_STATE_EVICTED = 9;
+
+  // The job timed out before it could complete.
+  JOB_STATE_TIMEOUT = 11;
+
+  // The job cannot be scheduled due the requried MAP being unavailable.
+  JOB_STATE_NOTREADY = 12;
+
+  // The job faulted due to an out of memory condition.
+  // This generally happens when requested memory is insufficient for the application.
+  JOB_STATE_EXCEEDED = 13;
+}
+
+// Request for Job::Cancel rpc.
+message JobCancelRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Unique identifier of the job.
+  Identifier job_id = 2;
+}
+
+// Response from Job::Cancel rpc.
+message JobCancelResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the job.
+  Identifier job_id = 2;
+}
+
+// Request for Job::Create rpc.
+message JobCreateRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // MAP to be used by the job.
+  oneof map {
+    // Unique identifier of the MAP.
+    Identifier map_id = 2;
+
+    // Unique reference name of the MAP.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    string map_name = 3;
+  }
+
+  // Priority to be assigned to the job.
+  JobPriority priority = 4;
+
+  // Unique identifier of the payload to use as input for the job.
+  Identifier payload_id = 5;
+
+  // URI of the service the server should notify when the job completes.
+  // The maximum allowed size is 2048 bytes.
+  string completion_uri = 6;
+}
+
+// Response from Job::Create rpc.
+message JobCreateResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the newly created job.
+  Identifier job_id = 2;
+
+  // Unique identifier of the MAP to be used by the job.
+  Identifier map_id = 3;
+
+  // Priority of the job.
+  JobPriority priority = 4;
+
+  // Currrent state of the job.
+  JobState state = 5;
+
+  // Unique identifier of the user account used to create the job.
+  // Represents an actual user account, and not a service account.
+  // User accounts are identified by the `RequestHeader.Authorization` message.
+  Identifier creator_id = 6;
+
+  // Unique identifier of the user account used to request the job creation.
+  // When `creator_id` and `requestor_id` differ, this value often represents a service account.
+  // User accounts are identified by the `RequestHeader.Authorization` message.
+  Identifier requestor_id = 7;
+}
+
+// Request for Job::Delete rpc.
+message JobDeleteRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Unique identifer of the job to delete.
+  Identifier job_id = 2;
+}
+
+message JobDeleteResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the job.
+  Identifier job_id = 2;
+}
+
+// Request for Jobs::List rpc.
+message JobListRequest {
+  message Filter {
+    // When provided, only jobs completed after the supplied timestamp will be returned.
+    Timestamp completed_after = 1;
+
+    // When provided, only jobs completed before the supplied timestamp will be returned.
+    Timestamp completed_before = 2;
+
+    // When provided, only jobs created after the supplied timestamp will be returned.
+    Timestamp created_after = 3;
+
+    // When provided, only jobs created before the supplied timestamp will be returned.
+    Timestamp created_before = 4;
+
+    // When provided, only jobs which used the specified MAP will be returned.
+    oneof map {
+      // Unique identifier of the map.
+      Identifier map_id = 5;
+
+      // Unique reference name of the MAP.
+      // Only provided when the MAP has a reference name.
+      // Reference name are compared using case insentitive comparator functions.
+      // The maximum allowed size for a reference name is 128 bytes.
+      string map_name = 6;
+    }
+
+    // When true, finalized jobs will not be returned; otherwise finalized jobs will be returned.
+    bool exclude_finalized = 7;
+
+    // When true, deleted jobs will be returned; otherwise deleted jobs will not be returned.
+    bool include_deleted = 8;
+
+    // When provided, only jobs matching these state(s) will not be returned.
+    repeated JobState excluded_states = 9;
+
+    // When provided, only jobs matching these state(s) will be returned.
+    repeated JobState included_states = 10;
+
+    // Unique identifier of the user account used to create the job.
+    // Represents an actual user account, and not a service account.
+    Identifier creator_id = 11;
+
+    // Unique identifier of the user account used to request the job creation.
+    // When `creator_id` and `requestor_id` differ, this value often represents a service account.
+    Identifier requestor_id = 12;
+  }
+
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Filters applied the possible list of jobs returned.
+  Filter filter = 2;
+}
+
+// Result from Job::List rpc.
+message JobListResponse {
+  message JobInfo {
+    // Unique identifier of the job.
+    Identifier job_id = 1;
+
+    // Unique identifier of the MAP used by the job.
+    Identifier map_id = 2;
+
+    // Current state of the job.
+    JobState state = 3;
+
+    // Priority of the job.
+    JobPriority priority = 4;
+
+    // True if the job has been finalized; otherwise false.
+    bool is_finalized = 5;
+
+    // True if the job record has been deleted; otherwise false.
+    bool is_deleted = 6;
+
+    // Timestamp describing when the job was created.
+    Timestamp created = 7;
+
+    // Unique identifier of the user account used to create the job.
+    // Represents an actual user account, and not a service account.
+    Identifier creator_id = 8;
+
+    // Unique identifier of the user account used to request the job creation.
+    // When `creator_id` and `requestor_id` differ, this value often represents a service account.
+    Identifier requestor_id = 9;
+  }
+
+  // Standard RPC response header (only included with first response in stream).
+  ResponseHeader header = 1;
+
+  // List of jobs.
+  // Note that this response is streamed, with a separate response per job being listed.
+  repeated JobInfo jobs = 2;
+}
+
+// Request for Job::Status rpc.
+message JobStatusRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Unique identifier of the job status is requested for.
+  Identifier job_id = 2;
+
+  // When true, job logs are returned; otherwise logs are not returned.
+  bool include_logs = 4;
+
+  // When true, the history of the job is returned; otherwise history is not returned.
+  bool include_history = 4;
+}
+
+// Response from Job::Status rpc.
+message JobStatusResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the job status is being reported on.
+  Identifier job_id = 2;
+
+  // Unique identifier of the MAP to be used by the job.
+  Identifier map_id = 3;
+
+  // Priority of the job.
+  JobPriority priority = 4;
+
+  // Unique identifier of the user account used to create the job.
+  // Represents an actual user account, and not a service account.
+  Identifier creator_id = 8;
+
+  // Unique identifier of the user account used to request the job creation.
+  // When `creator_id` and `requestor_id` differ, this value often represents a service account.
+  Identifier requestor_id = 9;
+
+  // Current state of the job.
+  JobState state = 12;
+
+  // True if the job has been removed; otherwise false.
+  bool is_finalized = 13;
+
+  // True if the job record has been deleted; otherwise false.
+  bool is_deleted = 14;
+
+  // Timestamp describing when the job was created.
+  Timestamp created = 16;
+
+  // Timestamp describing when the job started.
+  // Value will not be provided if the job has not yet started.
+  Timestamp started = 17;
+
+  // Timestamp describing when the job was stopped.
+  // Value will not be provided if the job has not yet stopped.
+  Timestamp stopped = 18;
+
+  // Timestamp describing when a job was marked as finalized.
+  // Value will not be provided if the job has not yet been finalized.
+  Timestamp finalized = 19;
+
+  // Timestamp when the job was deleted.
+  // No value will be provided if the job has not yet been deleted.
+  Timestamp deleted = 20;
+
+  // History of the job.
+  // Only provided when include_history = true.
+  repeated HistoricalEvent history = 24;
+
+  // Job logs.
+  // Logs are returned as a series of log lines.
+  // Maximum size is 65536 bytes (64 KiB) per entry.
+  // Only provided when include_logs = true
+  repeated string logs = 25;
+}

--- a/server-api/grpc/job.proto
+++ b/server-api/grpc/job.proto
@@ -179,14 +179,8 @@ message JobCreateResponse {
   JobState state = 5;
 
   // Unique identifier of the user account used to create the job.
-  // Represents an actual user account, and not a service account.
   // User accounts are identified by the `RequestHeader.Authorization` message.
-  Identifier creator_id = 6;
-
-  // Unique identifier of the user account used to request the job creation.
-  // When `creator_id` and `requestor_id` differ, this value often represents a service account.
-  // User accounts are identified by the `RequestHeader.Authorization` message.
-  Identifier requestor_id = 7;
+  Identifier user_id = 6;
 }
 
 // Request for Job::Delete rpc.
@@ -265,12 +259,7 @@ message JobListRequest {
     repeated JobState included_states = 10;
 
     // Unique identifier of the user account used to create the job.
-    // Represents an actual user account, and not a service account.
-    Identifier creator_id = 11;
-
-    // Unique identifier of the user account used to request the job creation.
-    // When `creator_id` and `requestor_id` differ, this value often represents a service account.
-    Identifier requestor_id = 12;
+    Identifier user_id = 11;
   }
 
   // Standard RPC request header.
@@ -305,12 +294,8 @@ message JobListResponse {
     Timestamp created = 7;
 
     // Unique identifier of the user account used to create the job.
-    // Represents an actual user account, and not a service account.
-    Identifier creator_id = 8;
-
-    // Unique identifier of the user account used to request the job creation.
-    // When `creator_id` and `requestor_id` differ, this value often represents a service account.
-    Identifier requestor_id = 9;
+    // User accounts are identified by the `RequestHeader.Authorization` message.
+    Identifier user_id = 8;
   }
 
   // Standard RPC response header (only included with first response in stream).
@@ -351,12 +336,8 @@ message JobStatusResponse {
   JobPriority priority = 4;
 
   // Unique identifier of the user account used to create the job.
-  // Represents an actual user account, and not a service account.
-  Identifier creator_id = 8;
-
-  // Unique identifier of the user account used to request the job creation.
-  // When `creator_id` and `requestor_id` differ, this value often represents a service account.
-  Identifier requestor_id = 9;
+  // User accounts are identified by the `RequestHeader.Authorization` message.
+  Identifier user_id = 8;
 
   // Current state of the job.
   JobState state = 12;

--- a/server-api/grpc/map.proto
+++ b/server-api/grpc/map.proto
@@ -35,7 +35,7 @@ service Map {
   // Restoring a MAP registration does restore any deleted reference names.
   // Attempting to restore a MAP registration which is not deleted with result in an error.
   // Attempting to restore an unknown MAP registration will result in an error.
-  rpc Restore(MapRestorRequest) returns (MapRestoreResponse);
+  rpc Restore(MapRestoreRequest) returns (MapRestoreResponse);
 
   // Requests the status of a known map.
   rpc Status(MapStatusRequest) returns (stream MapStatusResponse);
@@ -263,7 +263,7 @@ message MapReferenceUpdateResponse {
 }
 
 // Request for Map::Restore rpc.
-message MapRestorRequest {
+message MapRestoreRequest {
   // Standard RPC request header.
   RequestHeader header = 1;
 
@@ -328,7 +328,8 @@ message MapStatusResponse {
   // Current state of the MAP registation.
   MapState state = 4;
 
-  // Unique identifier of the user that created the MAP registation.
+  // Unique identifier of the user account used to create the MAP registration.
+  // User accounts are identified by the `RequestHeader.Authorization` message.
   string user_id = 5;
 
   // Timestamp of when the MAP registation was created.

--- a/server-api/grpc/map.proto
+++ b/server-api/grpc/map.proto
@@ -1,0 +1,351 @@
+syntax = "proto3";
+
+package monai.deploy.server;
+
+option csharp_namespace = "Monai.Deploy.Server.Grpc";
+option go_package = "apis";
+option java_package = "com.monai.deploy.server.grpc";
+
+import public "common.proto";
+
+// Service for managing MONAI Application Packages (MAP).
+service Map {
+  // Requests the creation of a new MAP registation.
+  // Attempting to create a MAP with an already known container URN will result in an error.
+  rpc Create(MapCreateRequest) returns (MapCreateResponse);
+
+  // Requests the deletion of a known MAP registation.
+  // Identifying the MAP registration to delete by reference name will also delete the reference name.
+  // Attempting to delete a MAP registration with reference names will result in an error.
+  // Attempting to delete an unknown or already deleted MAP registation will result in an error.
+  rpc Delete(MapRemoveRequest) returns (MapRemoveResponse);
+
+  // Requests a filtered list of know MAP records.
+  // When no filter is provided, the default filter will be used.
+  rpc List(MapListRequest) returns (stream MapListResponse);
+
+  // Requests the deletion of a MAP reference name.
+  rpc ReferenceDelete(MapReferenceDeleteRequest) returns (MapReferenceDeleteResponse);
+
+  // Requests for a reference name to refer to known MAP.
+  // Attempting to reference a deleted or error-state MAP will result in an error.
+  rpc ReferenceUpdate(MapReferenceUpdateRequest) returns (MapReferenceUpdateResponse);
+
+  // Requests for a deleted MAP registration to restored (undeleted).
+  // Restoring a MAP registration does restore any deleted reference names.
+  // Attempting to restore a MAP registration which is not deleted with result in an error.
+  // Attempting to restore an unknown MAP registration will result in an error.
+  rpc Restore(MapRestorRequest) return (MapRestoreResponse);
+
+  // Requests the status of a known map.
+  rpc Status(MapStatusRequest) returns (stream MapStatusResponse);
+}
+
+enum MapState {
+  // The MAP is unknown or the state of the MAP is unknown.
+  // New jobs cannot be created using this MAP registration.
+  MAP_STATE_UNKNOWN = 0;
+
+  // Creation of the MAP registration has been requested, but has not yet started.
+  // New jobs cannot be created using this MAP registration.
+  MAP_STATE_PENDING = 1;
+
+  // The server is in-progress of importing the MAP for usage.
+  // New jobs cannot be created using this MAP registration.
+  MAP_STATE_IMPORTING = 2;
+
+  // The MAP is ready for use.
+  // New jobs can be created using this MAP registration.
+  MAP_STATE_READY = 3;
+
+  // MAP import failed because the MAP is not a valid MONAI application package.
+  // New jobs cannot be created using this MAP registration.
+  MAP_STATE_INVALID = 4;
+
+  // MAP import failed because the its container image is unreachable.
+  // New jobs cannot be created using this MAP registration.
+  MAP_STATE_MISSING = 5;
+}
+
+// Request for Map::Create rpc.
+message MapCreateRequest {
+  // Standard request header.
+  RequestHeader header = 1;
+
+  // Universal resource name of the container image of the MAP.
+  // This is used to fetch the MAP and make it available to be associated with jobs.
+  string containerUrn = 2;
+
+  // Reference name to assign to the MAP registration.
+  // Duplicate reference names are not allowed, and will cause MAP creation to fail.
+  // Reference Names can be updated to refer to a different MAP in the future.
+  // Reference Names are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string map_name = 2;
+
+  // When true, an existing reference name can be updated; otherwise an error will be returned.
+  bool take_reference_name = 3;
+}
+
+// Response from Map::Create rpc.
+message MapCreateResponse {
+  // Standard response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the MAP registration.
+  Identifier map_id = 2;
+
+  // Reference name assigned to the MAP registration at creation.
+  // No value will be provided if a reference name was not provided in the creation request.
+  // Reference Names are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string map_name = 3;
+
+  // Current state of the MAP
+  MapState state = 4;
+}
+
+// Request for Map::Delete rpc.
+message MapDeleteRequest {
+  // Standard request header.
+  RequestHeader header = 1;
+
+  // Identifier of the MAP registration registration to delete.
+  oneof identifer {
+    // Unique identifier of the MAP registration to delete.
+    Identifier map_id = 2;
+
+    // Reference name which refers to the MAP registration to delete.
+    // When identifying a MAP by reference name, for deletion, the reference name used will also be deleted.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    string map_name = 3;
+  }
+
+  // When true all reference names which refer to MAP registration to be deleted, will also be deleted; otherwise a MAP registration with reference names cannot be deleted.
+  bool force = 4;
+}
+
+// Response from Map::Delete rpc.
+message MapDeleteResponse {
+  // Standard response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the deleted MAP.
+  Identifier map_id = 2;
+}
+
+// Request for Map::List rpc.
+message MapListRequest {
+  message Filter {
+    // When provided, only MAP records created after the supplied timestamp will be returned.
+    Timestamp created_after = 1;
+
+    // When provided, only MAP records created before the supplied timestamp will be returned.
+    Timestamp created_before = 2;
+
+    // When true, unnamed MAP records will be included in the set returned; otherwise unnamed MAP records are not returned.
+    bool include_unnamed = 4;
+
+    // When true, deleted MAP records will be included in the set returned; otherwise deleted MAP records are not returned.
+    bool include_deleted = 5;
+
+    // When provided, only MAP records matching these state(s) will not be returned.
+    repeated MapState excluded_states = 6;
+
+    // When provided, only MAP records matching these state(s) will be returned.
+    repeated MapState included_states = 7;
+
+    // When provided, only MAP records created by the supplied user will be returned.
+    Identifier user_id = 8;
+
+    // When true, supported input and output details returned for each MAP; otherwise input and output details are not returned.
+    bool include_io_specs = 9;
+  }
+
+  // Standard request header.
+  RequestHeader header = 1;
+
+  // List filter.
+  Filter filter = 2;
+}
+
+// Response from Map::List rpc.
+message MapListResponse {
+  message MapInfo {
+    // Unique identifier of the MAP registration.
+    Identifier map_id = 1;
+
+    // Reference name(s) which refer to the MAP registration.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    repeated string map_names = 2;
+
+    // Current state of the MAP registration.
+    MapState state = 3;
+
+    // Timestamp when the MAP registration was created.
+    Timestamp created = 4;
+
+    // True if the MAP registration has been deleted; otherwise false.
+    bool is_deleted = 5;
+
+    // UTF-8 encoded JSON data specifying the output type, layout, and format of the MAP.
+    // Only provided when include_io_specs is true.
+    // Data schema is unspecified.
+    // The maximum size returned is 4096 bytes.
+    string output_format = 6;
+
+    // UTF-8 encoded JSON data specifying the type, layout, format, and protocols of supported inputs for the MAP.
+    // Only provided when include_io_specs is true.
+    // Data schema is unspecified.
+    // The maximum size returned is 4096 bytes per format.
+    repeated string input_formats = 7;
+  }
+
+  // Standard response header.
+  ResponseHeader header = 1;
+
+  // List of MAP registation returned by the server.
+  repeated MapInfo maps = 2;
+}
+
+// Request for Map::ReferenceDelete rpc.
+message MapReferenceDeleteRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Reference name to delete.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string map_name = 2;
+}
+
+// Response from Map::ReferenceDelete rpc.
+message MapReferenceDeleteResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Reference name which was just deleted.
+  string map_name = 2;
+}
+
+// Request for Map::ReferenceUpdate rpc.
+message MapReferenceUpdateRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Unique identifier of the MAP registation to refer to.
+  Identifier map_id = 2;
+
+  // Reference name to be updated.
+  // If the reference name does not already exist, it will be created.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string map_name = 3;
+
+  // When true, an existing reference name can be updated; otherwise an error will be returned.
+  bool take_reference_name = 4;
+}
+
+// Response from Map::UpdateResponse rpc.
+message MapReferenceUpdateResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the MAP registation the reference name refers to.
+  Identifier map_id = 2;
+
+  // Updated reference name.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string map_name = 3;
+}
+
+// Request for Map::Restore rpc.
+message MapRestorRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Unique identifier of the MAP registration to restore.
+  Identifier map_id = 2;
+}
+
+// Response from Map::Restore rpc.
+message MapRestoreResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the updated MAP registation.
+  Identifier map_id = 2;
+}
+
+// Request for Map::Status rpc.
+message MapStatusRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Identifier of the MAP to query.
+  oneof identifier {
+    // Unique identifier of the MAP registation to query.
+    Identifier map_id = 2;
+
+    // Reference name of the MAP registation to query.
+    string map_name = 3;
+  }
+
+  // When true, the manifests of the MAP are returned; otherwise the manifests are not returned.
+  bool include_manifests = 4;
+
+  // When true, the history of the MAP is returned; otherwise history is not returned.
+  bool include_history = 5;
+}
+
+// Response for Map::Status rpc.
+message MapStatusResponse {
+  message Manifest {
+    // The name of the manifest.
+    // Maximum size of 256 bytes.
+    string name = 1;
+
+    // UTF-8 encoded manifest content.
+    // The maximum allowed size is 4194304 bytes (4 MiB).
+    string content = 2;
+  }
+
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the MAP.
+  Identifier map_id = 2;
+
+  // Reference name(s) which refer to the MAP registration.
+  // Only provided when the MAP registation has referring reference names.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  repeated string map_names = 3;
+
+  // Current state of the MAP registation.
+  MapState state = 4;
+
+  // Unique identifier of the user that created the MAP registation.
+  string user_id = 5;
+
+  // Timestamp of when the MAP registation was created.
+  Timestamp created = 6;
+
+  // True when the MAP registation is deleted; otherwise false.
+  string is_deleted = 7;
+
+  // Timestamp of when the MAP registation was deleted.
+  // No value will be provided if the MAP registation has not been deleted.
+  Timestamp deleted = 8;
+
+  // UTF-8 encoded JSON format application manifest of the MAP.
+  // Only provided when include_manifests is true.
+  repeated Manifest manifests = 16;
+
+  // History of the MAP registation.
+  // Only provided when include_history is true.
+  repeated HistoricalEvent history = 24;
+}

--- a/server-api/grpc/map.proto
+++ b/server-api/grpc/map.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package monai.deploy.server;
+package monai.deploy.platform;
 
-option csharp_namespace = "Monai.Deploy.Server.Grpc";
-option go_package = "apis";
-option java_package = "com.monai.deploy.server.grpc";
+option csharp_namespace = "Monai.Deploy.Platform.Grpc";
+option go_package = "monaid.grpc";
+option java_package = "com.monai.deploy.platform.grpc";
 
 import public "common.proto";
 
@@ -18,7 +18,7 @@ service Map {
   // Identifying the MAP registration to delete by reference name will also delete the reference name.
   // Attempting to delete a MAP registration with reference names will result in an error.
   // Attempting to delete an unknown or already deleted MAP registation will result in an error.
-  rpc Delete(MapRemoveRequest) returns (MapRemoveResponse);
+  rpc Delete(MapDeleteRequest) returns (MapDeleteResponse);
 
   // Requests a filtered list of know MAP records.
   // When no filter is provided, the default filter will be used.
@@ -35,7 +35,7 @@ service Map {
   // Restoring a MAP registration does restore any deleted reference names.
   // Attempting to restore a MAP registration which is not deleted with result in an error.
   // Attempting to restore an unknown MAP registration will result in an error.
-  rpc Restore(MapRestorRequest) return (MapRestoreResponse);
+  rpc Restore(MapRestorRequest) returns (MapRestoreResponse);
 
   // Requests the status of a known map.
   rpc Status(MapStatusRequest) returns (stream MapStatusResponse);
@@ -81,10 +81,10 @@ message MapCreateRequest {
   // Reference Names can be updated to refer to a different MAP in the future.
   // Reference Names are compared using case insentitive comparator functions.
   // The maximum allowed size for a reference name is 128 bytes.
-  string map_name = 2;
+  string map_name = 3;
 
   // When true, an existing reference name can be updated; otherwise an error will be returned.
-  bool take_reference_name = 3;
+  bool take_reference_name = 4;
 }
 
 // Response from Map::Create rpc.

--- a/server-api/grpc/payload.proto
+++ b/server-api/grpc/payload.proto
@@ -144,16 +144,16 @@ message PayloadFileDetails {
 
 // Request for Payload::Create rpc.
 message PayloadCreateRequest {
-  message Source {
-    // Unique (within a payload) name of the folder to where source payload content will be placed; in path format.
-    // This value can be empty (or not provided) when only a single source payload is used to create a new payload.
-    // When this value is not empty, resulting file names will have this value and a path separator character prepended to them.
-    // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
-    // File names are case sensitive.
-    // Maximum allowed size for a file name is 4096 bytes.
-    string path = 1;
-
 /** Feature Not Available in Current Version
+ * message Source {
+ *   // Unique (within a payload) name of the folder to where source payload content will be placed; in path format.
+ *   // This value can be empty (or not provided) when only a single source payload is used to create a new payload.
+ *   // When this value is not empty, resulting file names will have this value and a path separator character prepended to them.
+ *   // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+ *   // File names are case sensitive.
+ *   // Maximum allowed size for a file name is 4096 bytes.
+ *   string path = 1;
+ *
  *   // Identifier of the source payload to clone.
  *   oneof identifier {
  *     // Unique identifier of the source payload.
@@ -168,8 +168,8 @@ message PayloadCreateRequest {
  *     // The maximum allowed size for a reference name is 128 bytes.
  *     string payload_name = 4;
  *   }
+ * }
 **/
-  }
 
   // Standard RPC request header.
   RequestHeader header = 1;
@@ -184,10 +184,12 @@ message PayloadCreateRequest {
   // When true, an existing reference name can be updated; otherwise an error will be returned.
   bool take_reference_name = 3;
 
-  // When provided, list of source payloads from which content will be copied into the new payload.
-  // Each source payload will have its contents mapped to a path relative to the root of the new payload.
-  // Each source payload must have a unique path; otherwise an error will be returned.
-  repeated Source sources = 4;
+/** Feature Not Available in Current Version
+ * // When provided, list of source payloads from which content will be copied into the new payload.
+ * // Each source payload will have its contents mapped to a path relative to the root of the new payload.
+ * // Each source payload must have a unique path; otherwise an error will be returned.
+ * repeated Source sources = 4;
+**/
 }
 
 // Response from Payload::Create rpc.

--- a/server-api/grpc/payload.proto
+++ b/server-api/grpc/payload.proto
@@ -1,0 +1,547 @@
+syntax = "proto3";
+
+package monai.deploy.server;
+
+option csharp_namespace = "Monai.Deploy.Server.Grpc";
+option go_package = "apis";
+option java_package = "com.monai.deploy.server";
+
+import public "common.proto";
+
+// Service for managing payloads.
+service Payload {
+/** Feature Not Available in Current Version
+ * // Request content from one payload to be copied to another payload.
+ * // The source and target payloads will be considered busy during the copy operation; busy payloads cannot be deleted or modified.
+ * // Results of this RPC are streamed while file copies are happening.
+ * // Requesting copy from or to a deleted payload will result in an error.
+ * // Requesting copy to a payload associated with a pending or running job will result in an error.
+ * rpc Copy(stream PayloadCopyRequest) returns (stream PayloadCopyResponse);
+**/
+
+  // Requests the creation of a new payload.
+  // New payloads can be created using the contents of existing payload(s).
+  // Results of this RPC are streamed when file copies are happening.
+  rpc Create(stream PayloadCreateRequest) returns (stream PayloadCreateResponse);
+
+  // Requests the deletion of a known payload.
+  // Requesting deletion of a payload associated with a pending or running job will result in an error.
+  // Requesting deletion of a referenced payload will result in an error.
+  // Deleted payloads are not returned by List by default.
+  rpc Delete(PayloadDeleteRequest) returns (PayloadDeleteResponse);
+
+  // Requests the download of a blob (file) from a known payload.
+  // Requesting the download a blob from a deleted payload will result in an error.
+  rpc FileDownload(PayloadFileDownloadRequest) returns (stream PayloadFileDownloadResponse);
+
+  // Requests the removal, or deletion, of a blob (file) from a known payload.
+  // Requesting  removal of a blob from a payload associated with a pending, running, or completed job will result in an error.
+  rpc FileRemove(PayloadRemoveRequest) returns (PayloadRemoveResponse);
+
+  // Requests the upload of a blob (file) to a known payload.
+  // Requesting to upload a blob to a payload associated with a pending, running, or complete job will result in an error.
+  // Requesting to upload a blob which will result in a name collision will result in an error.
+  rpc FileUpload(stream PayloadFileUploadRequest) returns (PayloadFileUploadResponse);
+
+  // Requests a filtered list of payloads known payloads.
+  // When no filter is provided, the default filter will be used.
+  rpc List(PayloadListRequest) return (stream PayloadListResponse);
+
+  // Requests the deletion of a payload reference name.
+  // Requesting deletion of an unknown reference name will result in an error.
+  rpc ReferenceDelete(PayloadReferenceDeleteRequest) return (PayloadReferenceDeleteResponse);
+
+  // Requests for a reference name to refer to known payload.
+  // Requesting to reference a deleted payload will result in an error.
+  // Requesting to assign more than one reference name to a payload will result in an error.
+  rpc ReferenceUpdate(PayloadReferenceUpdateRequest) returns (PayloadReferenceUpdateResponse);
+
+  // Requests the status of a known payload.
+  // Payload status includes the list of files contained by the payload.
+  rpc Status(PayloadStatusRequest) returns (stream PayloadStatusResponse);
+}
+
+// Information about a file contained in a payload.
+message PayloadFileDetails {
+  // 8-bit "mode" of the file.
+  uint32 mode = 1;
+
+  // Size, in bytes, of the file.
+  uint64 size = 2;
+
+  // Unique (within a payload) name of the file; in path format.
+  // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+  // File names are case-sensitive.
+  // Maximum allowed size for a file name is 4096 bytes.
+  string path = 3;
+}
+
+/** Feature Not Available in Current Version
+ * // Request for Payload::Copy rpc.
+ * message PayloadCopyRequest {
+ *   message FileCopy {
+ *     // Name of the file in the source payload to copy.
+ *     // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+ *     // File names are case-sensitive.
+ *     // Maximum allowed size for a file name is 4096 bytes.
+ *     string source_path = 1;
+ *
+ *     // Name of the file in the target payload to create.
+ *     // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+ *     // File names are case-sensitive.
+ *     // Maximum allowed size for a file name is 4096 bytes.
+ *     string target_path = 2;
+ *   }
+ *   // Standard RPC request header.
+ *   RequestHeader header = 1;
+ *
+ *   // Identifier of the payload to copy from.
+ *   oneof source {
+ *     // Unique identifier of the payload to copy from.
+ *     // Providing the identifier for a payload which is writable will result in an error.
+ *     // Payloads are writable from creation until they're assigned to a job.
+ *     Identifier source_payload_id = 2;
+ *
+ *     // Unique identifier of the pjob to copy from.
+ *     // Providing an identifier of a not completed job will result in an error.
+ *     Identifier source_job_id = 3;
+ *
+ *     // Reference name which refers to the payload to copy from.
+ *     // Reference name are compared using case insentitive comparator functions.
+ *     // The maximum allowed size for a reference name is 128 bytes.
+ *     string source_payload_name = 4;
+ *   }
+ *
+ *   // Identifier of the payload to copy to.
+ *   oneof target {
+ *     // Unique identifier of the payload to copy to.
+ *     Identifier target_id = 5;
+ *
+ *     // Reference name which refers to the payload to copy to.
+ *     // Reference name are compared using case insentitive comparator functions.
+ *     // The maximum allowed size for a reference name is 128 bytes.
+ *     string target_name = 6;
+ *   }
+ *
+ *   // Set of files to be copied from the source to the target payload.
+ *   // File names must be unique; if a file already exists in the target payload an error will be returned.
+ *   // Folders cannot be copied; if a folder name is provided an error will be returned.
+ *   repeated FileCopy files = 7;
+ * }
+ *
+ * // Response for Payload::Copy rpc.
+ * message PayloadCopyResponse {
+ *   // Standard RPC response header.
+ *   ResponseHeader header = 1;
+ *
+ *   // List of files, in the target payload, which have been successfully copied.
+ *   // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+ *   // File names are case-sensitive.
+ *   // Maximum allowed size for a file name is 4096 bytes.
+ *   repeated string copied_files = 2;
+ * }
+**/
+
+// Request for Payload::Create rpc.
+message PayloadCreateRequest {
+  message Source {
+    // Unique (within a payload) name of the folder to where source payload content will be placed; in path format.
+    // This value can be empty (or not provided) when only a single source payload is used to create a new payload.
+    // When this value is not empty, resulting file names will have this value and a path separator character prepended to them.
+    // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+    // File names are case sensitive.
+    // Maximum allowed size for a file name is 4096 bytes.
+    string path = 1;
+
+/** Feature Not Available in Current Version
+ *   // Identifier of the source payload to clone.
+ *   oneof identifier {
+ *     // Unique identifier of the source payload.
+ *     Identifier payload_id = 2;
+ *
+ *     // Unique identifier of the source job.
+ *     // Job identifier content is from the job's result payload.
+ *     Identifier job_id = 3;
+ *
+ *     // Reference name which refers to the source payload.
+ *     // Reference name are compared using case insentitive comparator functions.
+ *     // The maximum allowed size for a reference name is 128 bytes.
+ *     string payload_name = 4;
+ *   }
+**/
+  }
+
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Reference name to assign to the payload.
+  // Duplicate reference names are not allowed, and will cause payload creation to fail.
+  // Reference Names can be updated to refer to a different payload in the future.
+  // Reference Names are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string payload_name = 2;
+
+  // When true, an existing reference name can be updated; otherwise an error will be returned.
+  bool take_reference_name = 3;
+
+  // When provided, list of source payloads from which content will be copied into the new payload.
+  // Each source payload will have its contents mapped to a path relative to the root of the new payload.
+  // Each source payload must have a unique path; otherwise an error will be returned.
+  repeated Source sources = 4;
+}
+
+// Response from Payload::Create rpc.
+message PayloadCreateResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the new payload.
+  Identifier payload_id = 2;
+
+  // Reference name assigned to the payload at creation.
+  // Not provided if the request did not include a reference name assignment.
+  string payload_name = 3;
+
+  // List of files, in the new payload, copied into the new payload from source payloads.
+  // Not provided if no source payloads were provided.
+  // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+  // File names are case sensitive.
+  // Maximum allowed size for a file name is 4096 bytes.
+  repeated string file_name = 4;
+}
+
+// Request for Payload::Delete rpc.
+message PayloadDeleteRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Identifier of the payload to delete.
+  oneof identifier {
+    // Unique identifier of the payload to delete.
+    Identifier payload_id = 2;
+
+    // Reference name which refers to the payload to delete.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    string payload_name = 3;
+
+    // Unique identifier of the job associated with the payload.
+    // Files downloaded using the job identifier downloads from the job's result payload.
+    Identifier job_id = 4;
+  }
+
+  // When true all reference names which refer to payload to be deleted, will also be deleted; otherwise a payload with reference names cannot be deleted.
+  bool force = 5;
+}
+
+// Response from Payload::Delete rpc.
+message PayloadDeleteResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the deleted payload.
+  Identifier payload_id = 2;
+}
+
+
+// Request for Payload::FileDownload rpc.
+message PayloadFileDownloadRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  oneof identifier {
+    // Unique identifier of the payload.
+    Identifier payload_id = 2;
+
+    // Reference name which refers to the payload.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    string payload_name = 3;
+
+    // Unique identifier of the job associated with the payload.
+    // Files downloaded using the job identifier downloads from the job's result payload.
+    Identifier job_id = 4;
+  }
+
+  // Unique (within a payload) path of a file; in path format.
+  // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+  // File names are case-sensitive.
+  string path = 5;
+}
+
+// Response from Payload::FileDownload rpc.
+message PayloadFileDownloadResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the payload.
+  Identifier payload_id = 2;
+
+  // Details of the file being downloaded.
+  PayloadFileDetails details = 3;
+
+  // Bytes of the file being downloaded.
+  bytes data = 4;
+}
+
+// Request for Payload::FileRemove rpc.
+message PayloadFileRemoveRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  oneof identifier {
+    // Unique identifier of the payload.
+    Identifier payload_id = 2;
+
+    // Reference name which refers to the payload.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    string payload_name = 3;
+  }
+
+  // Unique (within a payload) path of a file; in path format.
+  // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+  // File names are case-sensitive.
+  string path = 4;
+}
+
+// Response from Payload::Remove rpc.
+message PayloadFileRemoveResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the payload.
+  Identifier payload_id = 2;
+
+  // Unique (within a payload) path of a file; in path format.
+  // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+  // File names are case-sensitive.
+  string path = 3;
+}
+
+// Request for Payload::FileUpload rpc.
+message PayloadFileUploadRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Identifier of the payload.
+  oneof identifier {
+    // Unique identifier of the payload.
+    Identifier payload_id = 2;
+
+    // Reference name which refers to the payload.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    string payload_name = 3;
+  }
+
+  // The payload root relative path where the file is to be stored in the payload.
+  string path = 4;
+
+  // Raw content of the file being uploaded.
+  bytes data = 5;
+}
+
+// Response from Payload::FileUpload rpc.
+message PayloadFileUploadResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the payload.
+  Identifier payload_id = 2;
+
+  // Details about the uploaded file.
+  PayloadFileDetails = 3;
+}
+
+// Request for Payload::List rpc.
+message PayloadListRequest {
+  message Filter {
+    // When provided, only payloads created after the supplied timestamp will be returned.
+    Timestamp created_after = 1;
+
+    // When provided, only payloads created before the supplied timestamp will be returned.
+    Timestamp created_before = 2;
+
+    // When provided, only payloads assocated with the job identifier will be returned.
+    Identifier job_id = 3;
+
+    // When true, unnamed payloads will be included in the set returned; otherwise unnamed payloads are not returned.
+    bool include_unnamed = 4;
+
+    // When true, deleted payloads will be included in the set returned; otherwise deleted payloads are not returned.
+    bool include_deleted = 5;
+
+    // When provided, only payloads created by the supplied user will be returned.
+    Identifier user_id = 6;
+  }
+
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // List filter.
+  Filter filter = 2;
+}
+
+// Response from Payload::List rpc.
+message PayloadListResponse {
+  message PayloadInfo {
+    // Unique identifier of the payload.
+    Identifier payload_id = 1;
+
+    // Unique identifier of the job which created the payload.
+    // No value will be provided when the payload was not created by a job.
+    // Each job creation creates a new results payload with the same identifier as the job.
+    Identifier job_id = 2;
+
+    // Reference name(s) which refer to the payload.
+    // Only provided when the payload has a reference name.
+    // Reference name are compared using case insentitive comparator functions.
+    // The maximum allowed size for a reference name is 128 bytes.
+    repeated string payload_names = 3;
+
+    // Timestamp when the payload was created.
+    Timestamp created = 4;
+
+    // True if the payload has been deleted; otherwise false.
+    bool is_deleted = 5;
+
+    // True if the payload is writable; otherwise false.
+    // Payloads which have been associated with jobs are not writable.
+    bool is_writable = 6;
+  }
+
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // List of payloads returned by the server.
+  repeated PayloadInfo payloads = 2;
+}
+
+// Request for Payload::ReferenceDelete rpc.
+message PayloadReferenceDeleteRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Reference name to delete.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string payload_name = 2;
+}
+
+// Response from Payload::ReferenceDelete rpc.
+message PayloadReferenceDeleteResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Reference name which was just deleted.
+  string payload_name = 2;
+}
+
+// Request for Payload::ReferenceUpdate rpc.
+message PayloadReferenceUpdateRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Unique identifier of the payload the reference name.
+  Identifier payload_id = 2;
+
+  // Reference name to update.
+  // If the reference name does not already exist, it will be created.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string payload_name = 3;
+
+  // When true, an existing reference name can be updated; otherwise an error will be returned.
+  bool take_reference_name = 4;
+}
+
+// Response from Payload::UpdateResponse rpc.
+message PayloadReferenceUpdateResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the payload the reference name refers to.
+  Identifier payload_id = 2;
+
+  // Updated reference name.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  string payload_name = 3;
+}
+
+// Request for Payload::Status rpc.
+message PayloadStatusRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+
+  // Identifier of the payload to query.
+  oneof identifier {
+    // Unique identifier of the payload to query.
+    Identifier payload_id = 2;
+
+    // Reference name of the payload to query.
+    string payload_name = 3;
+
+    // Unique identifier of the job to query.
+    // Only job results payloads can be queried this way.
+    Identifier job_id = 4;
+  }
+
+  // When true, the history of the payload is returned; otherwise history is not returned.
+  bool include_history = 5;
+}
+
+// Response from Payload::Status rpc.
+message PayloadStatusResponse {
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // Unique identifier of the payload.
+  Identifier payload_id = 2;
+
+  // Reference name(s) which refer to the payload.
+  // Only provided when the payload has a reference name.
+  // Reference name are compared using case insentitive comparator functions.
+  // The maximum allowed size for a reference name is 128 bytes.
+  repeated string payload_name = 4;
+
+  // Unique identifier of the user account used to create the payload.
+  // Represents an actual user account, and not a service account.
+  Identifier creator_id = 8;
+
+  // Unique identifier of the user account used to request the payload creation.
+  // When `creator_id` and `requestor_id` differ, this value often represents a service account.
+  Identifier requestor_id = 9;
+
+  // List of unique identifiers of jobs the payload has been associated with.
+  // No value will be provided when the payload has not yet been associated with any jobs.
+  repeated Identifier job_ids = 10;
+
+  // True when the payload is deleted; otherwise false.
+  bool is_deleted = 12;
+
+  // True when the payload is sealed; otherwise false.
+  bool is_sealed = 13;
+
+  // True if the payload is writable; otherwise false.
+  // Payloads which have been associated with jobs are no longer writable.
+  bool is_writable = 14;
+
+  // Timestamp of when the payload was created.
+  Timestamp created = 15;
+
+  // Timestamp of when the payload was deleted.
+  // No value will be provided if the payload has not yet been deleted.
+  Timestamp deleted = 16;
+
+  // Unique Identifier of the job(s) associated with the payload.
+  repeated Identifier job_ids = 17;
+
+  // Details of a file contained in the payload. Note that this response is streamed, with a separate response for each file in the payload.
+  repeated PayloadFileDetails files = 18;
+
+  // History of the payload.
+  // Only provided when include_history = true.
+  repeated HistoricalEvent history = 24;
+}

--- a/server-api/grpc/payload.proto
+++ b/server-api/grpc/payload.proto
@@ -203,13 +203,14 @@ message PayloadCreateResponse {
   // Reference name assigned to the payload at creation.
   // Not provided if the request did not include a reference name assignment.
   string payload_name = 3;
-
-  // List of files, in the new payload, copied into the new payload from source payloads.
-  // Not provided if no source payloads were provided.
-  // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
-  // File names are case sensitive.
-  // Maximum allowed size for a file name is 4096 bytes.
-  repeated string file_name = 4;
+/** Feature Not Available in Current Version
+ * // List of files, in the new payload, copied into the new payload from source payloads.
+ * // Not provided if no source payloads were provided.
+ * // File names are relative to the root of the payload, and should not be rooted paths (prefixed with a '/' character).
+ * // File names are case sensitive.
+ * // Maximum allowed size for a file name is 4096 bytes.
+ * repeated string file_name = 4;
+**/
 }
 
 // Request for Payload::Delete rpc.
@@ -375,6 +376,7 @@ message PayloadListRequest {
     bool include_deleted = 5;
 
     // When provided, only payloads created by the supplied user will be returned.
+    // User accounts are identified by the `RequestHeader.Authorization` message.
     Identifier user_id = 6;
   }
 
@@ -508,37 +510,26 @@ message PayloadStatusResponse {
   // The maximum allowed size for a reference name is 128 bytes.
   repeated string payload_name = 4;
 
-  // Unique identifier of the user account used to create the payload.
-  // Represents an actual user account, and not a service account.
-  Identifier creator_id = 8;
-
   // Unique identifier of the user account used to request the payload creation.
-  // When `creator_id` and `requestor_id` differ, this value often represents a service account.
-  Identifier requestor_id = 9;
-
-  // List of unique identifiers of jobs the payload has been associated with.
-  // No value will be provided when the payload has not yet been associated with any jobs.
-  repeated Identifier job_ids = 10;
+  // User accounts are identified by the `RequestHeader.Authorization` message.
+  Identifier user_id = 8;
 
   // True when the payload is deleted; otherwise false.
   bool is_deleted = 12;
 
-  // True when the payload is sealed; otherwise false.
-  bool is_sealed = 13;
-
   // True if the payload is writable; otherwise false.
   // Payloads which have been associated with jobs are no longer writable.
-  bool is_writable = 14;
+  bool is_writable = 13;
 
   // Timestamp of when the payload was created.
-  Timestamp created = 15;
+  Timestamp created = 14;
 
   // Timestamp of when the payload was deleted.
   // No value will be provided if the payload has not yet been deleted.
-  Timestamp deleted = 16;
+  Timestamp deleted = 15;
 
   // Details of a file contained in the payload. Note that this response is streamed, with a separate response for each file in the payload.
-  repeated PayloadFileDetails files = 17;
+  repeated PayloadFileDetails files = 16;
 
   // History of the payload.
   // Only provided when include_history = true.

--- a/server-api/grpc/payload.proto
+++ b/server-api/grpc/payload.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package monai.deploy.server;
+package monai.deploy.platform;
 
-option csharp_namespace = "Monai.Deploy.Server.Grpc";
-option go_package = "apis";
-option java_package = "com.monai.deploy.server";
+option csharp_namespace = "Monai.Deploy.Platform.Grpc";
+option go_package = "monaid.grpc";
+option java_package = "com.monai.deploy.platform";
 
 import public "common.proto";
 
@@ -36,7 +36,7 @@ service Payload {
 
   // Requests the removal, or deletion, of a blob (file) from a known payload.
   // Requesting  removal of a blob from a payload associated with a pending, running, or completed job will result in an error.
-  rpc FileRemove(PayloadRemoveRequest) returns (PayloadRemoveResponse);
+  rpc FileRemove(PayloadFileRemoveRequest) returns (PayloadFileRemoveResponse);
 
   // Requests the upload of a blob (file) to a known payload.
   // Requesting to upload a blob to a payload associated with a pending, running, or complete job will result in an error.
@@ -45,11 +45,11 @@ service Payload {
 
   // Requests a filtered list of payloads known payloads.
   // When no filter is provided, the default filter will be used.
-  rpc List(PayloadListRequest) return (stream PayloadListResponse);
+  rpc List(PayloadListRequest) returns (stream PayloadListResponse);
 
   // Requests the deletion of a payload reference name.
   // Requesting deletion of an unknown reference name will result in an error.
-  rpc ReferenceDelete(PayloadReferenceDeleteRequest) return (PayloadReferenceDeleteResponse);
+  rpc ReferenceDelete(PayloadReferenceDeleteRequest) returns (PayloadReferenceDeleteResponse);
 
   // Requests for a reference name to refer to known payload.
   // Requesting to reference a deleted payload will result in an error.
@@ -63,8 +63,8 @@ service Payload {
 
 // Information about a file contained in a payload.
 message PayloadFileDetails {
-  // 8-bit "mode" of the file.
-  uint32 mode = 1;
+  // True when the file is to be considered executable; otherwise false.
+  bool is_executable = 1;
 
   // Size, in bytes, of the file.
   uint64 size = 2;
@@ -353,7 +353,7 @@ message PayloadFileUploadResponse {
   Identifier payload_id = 2;
 
   // Details about the uploaded file.
-  PayloadFileDetails = 3;
+  PayloadFileDetails details = 3;
 }
 
 // Request for Payload::List rpc.
@@ -537,11 +537,8 @@ message PayloadStatusResponse {
   // No value will be provided if the payload has not yet been deleted.
   Timestamp deleted = 16;
 
-  // Unique Identifier of the job(s) associated with the payload.
-  repeated Identifier job_ids = 17;
-
   // Details of a file contained in the payload. Note that this response is streamed, with a separate response for each file in the payload.
-  repeated PayloadFileDetails files = 18;
+  repeated PayloadFileDetails files = 17;
 
   // History of the payload.
   // Only provided when include_history = true.

--- a/server-api/grpc/platform.proto
+++ b/server-api/grpc/platform.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package monai.deploy.server;
+package monai.deploy.platform;
 
-option csharp_namespace = "Monai.Deploy.Server.Grpc";
-option go_package = "apis";
-option java_package = "com.monai.deploy.server.grpc";
+option csharp_namespace = "Monai.Deploy.Platform.Grpc";
+option go_package = "monaid.grpc";
+option java_package = "com.monai.deploy.platform.grpc";
 
 import public "common.proto";
 

--- a/server-api/grpc/platform.proto
+++ b/server-api/grpc/platform.proto
@@ -1,0 +1,122 @@
+syntax = "proto3";
+
+package monai.deploy.server;
+
+option csharp_namespace = "Monai.Deploy.Server.Grpc";
+option go_package = "apis";
+option java_package = "com.monai.deploy.server.grpc";
+
+import public "common.proto";
+
+service Platform {
+/** Feature Not Available in Current Version
+ * rpc ConfigurationRead(PlatformConfigurationReadRequest) return (PlatformConfigurationReadResponse);
+ *
+ * // Requests the status of the platform.
+ * rpc Status(PlatformStatusRequest) returns (PlatformStatusResponse);
+**/
+
+  // Requests the version of the server.
+  rpc Version(PlatformVersionRequest) returns (PlatformVersionResponse);
+}
+/** Feature Not Available in Current Version
+ * message ConfigurationJob {
+ *   // The default CPU request made for job based on a MAP which does not specify CPU requirements.
+ *   // The value must fall within the range of [cpu_resource_minimum, cpu_resource_maximum].
+ *   uint32 cpu_resource_default = 1;
+ *
+ *   // The maximum memory request which can be made by any job.
+ *   // The value must be greater-than-or-equal to cpu_resource_minimum value.
+ *   uint32 cpu_resource_maximum = 2;
+ *
+ *   // The minimum memory request which can be made by any job.
+ *   // The value must be less-than-or-equal to cpu_resource_maximum value.
+ *   uint32 cpu_resource_minimum = 3;
+ *
+ *   // The default memory request, in megabytes, made for job base on a MAP which does not specify memory requirements.
+ *   // The value must fall within the range of [memory_resource_minimum, memory_resource_maximum].
+ *   uint32 memory_resource_default = 1;
+ *
+ *   // The maximum memory request, in megabytes, which can be made by any job.
+ *   // The value must be greater-than-or-equal to memory_resource_minimum value.
+ *   uint32 memory_resource_maximum = 2;
+ *
+ *   // The minimum memory request, in megabytes, which can be made by any job.
+ *   // The value must be less-than-or-equal to memory_resource_maximum value.
+ *   uint32 memory_resource_minimum = 3;
+ *
+ *   // The default timeout applied to jobs based on a MAP which does not specify a timeout.
+ *   // The value must fall within the range of [timeout_minimum, timeout_maximum].
+ *   uint32 timeout_default = 1;
+ *
+ *   // The maximum timeout value a job can request.
+ *   // The value must greater-than-or-equal to timeout_minimum.
+ *   uint32 timeout_maximum = 1;
+ *
+ *   // The minimum timeout value a job can request.
+ *   // THe value must less-than-or-equal-to timeout_maximum.
+ *   uint32 timeout_minimum = 1;
+ * }
+ *
+ * message ConfigurationPayload {
+ *   // The default quota, in megabytes, applied payloads which do not specify a quota size.
+ *   // The value must be within the range (0, quota_maximum].
+ *   uint32 quota_default = 1;
+ *
+ *   // The maximum quota, in megabytes, allowed for payloads.
+ *   uint32 quota_maximum = 2;
+ *
+ *   // The time to live, in seconds, for a payload after it is no longer active.
+ *   // Payloads are considered active when have a reference name referring to them.
+ *   // Payloads are considered active when in active use (using Payload service to interact with them).
+ *   // Payloads are considered active when associated with a pending or running job.
+ *   // Once payload TTL expires, a payload is queued for garbage collection but might not be collected immediately.
+ *   uint32 ttl = 1;
+ *
+ *   // The maximum amount of storage the system will utilization allowed, represented as a percent of the total storage.
+ *   // The value must be in the range zero to one inclusive, with zero being empty storage and one being full storage.
+ *   // One the threshold is reached, the server will refuse to create new objects and accept payload blob uploads.
+ *   // Values greater than 0.85 may cause system instability.
+ *   float storage_use_limit = 1;
+ * }
+ *
+ * message PlatformConfigurationReadRequest {
+ *   // Standard RPC request header.
+ *   RequestHeader header = 1;
+ * }
+ *
+ * message PlatformConfigurationReadResponse {
+ *   // Standard RPC respose header.
+ *   ResponseHeader header = 1;
+ *
+ *   // The URI of the authority used to validate authentication tokens.
+ *   string authority_uri = 1;
+ *
+ *   ConfigurationJob job_configuration = 1;
+ *
+ *   ConfigurationPayload payload_configuration = 1;
+ * }
+ *
+ * message PlatformStatusRequest {
+ *   // Standard RPC request header.
+ *   RequestHeader header = 1;
+ * }
+ *
+ * message PlatformStatusResponse {
+ *   // Standard RPC respose header.
+ *   ResponseHeader header = 1;
+ * }
+**/
+
+message PlatformVersionRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+}
+
+message PlatformVersionResponse {
+  // Standard RPC respose header.
+  ResponseHeader header = 1;
+
+  // Version of the server.
+  Version version = 2;
+}

--- a/server-api/grpc/user.proto
+++ b/server-api/grpc/user.proto
@@ -33,11 +33,14 @@ message UserListRequest {
 message UserListResponse {
   message UserInfo {
     // Unique identifier of the user.
-    Identifier user_id = 2;
+    Identifier user_id = 1;
 
     // Display name of the user.
     // Maximum size for a user display name is 1024 bytes.
-    string display_name = 4;
+    string display_name = 2;
+
+    // Timestamp when the user-account was created.
+    Timestamp created = 8;
   }
 
   // Standard RPC response header.

--- a/server-api/grpc/user.proto
+++ b/server-api/grpc/user.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package monai.deploy.server;
+package monai.deploy.platform;
 
-option csharp_namespace = "Monai.Deploy.Server.Grpc";
-option go_package = "apis";
-option java_package = "com.monai.deploy.server.grpc";
+option csharp_namespace = "Monai.Deploy.Platform.Grpc";
+option go_package = "monaid.grpc";
+option java_package = "com.monai.deploy.platform.grpc";
 
 import public "common.proto";
 

--- a/server-api/grpc/user.proto
+++ b/server-api/grpc/user.proto
@@ -1,0 +1,115 @@
+syntax = "proto3";
+
+package monai.deploy.server;
+
+option csharp_namespace = "Monai.Deploy.Server.Grpc";
+option go_package = "apis";
+option java_package = "com.monai.deploy.server.grpc";
+
+import public "common.proto";
+
+// Service for managing user accounts.
+service User {
+  // Requests a filtered list of known users.
+  // When no filter is provided, the default filter will be used.
+  rpc List(UserListRequest) returns (stream UserListResponse);
+
+/** Feature Not Available in Current Version
+ * // Requests a user accounts privileges to be updated.
+ * rpc Privileges(UserPrivilegesRequest) returns (UserPrivilegesResponse);
+ *
+ * // Requests the status of a known user.
+ * rpc Status(UserStatusRequest) returns (stream UserStatusResponse);
+**/
+}
+
+// Request for User::List rpc.
+message UserListRequest {
+  // Standard RPC request header.
+  RequestHeader header = 1;
+}
+
+// Response from User::List rpc.
+message UserListResponse {
+  message UserInfo {
+    // Unique identifier of the user.
+    Identifier user_id = 2;
+
+    // Display name of the user.
+    // Maximum size for a user display name is 1024 bytes.
+    string display_name = 4;
+  }
+
+  // Standard RPC response header.
+  ResponseHeader header = 1;
+
+  // List of users.
+  repeated UserInfo users = 2;
+}
+
+/** Feature Not Available in Current Version
+ * // Request for User::Status rpc.
+ * message UserStatusRequest {
+ *   // Standard RPC request header.
+ *   RequestHeader header = 1;
+ *
+ *   // When true, the history of the user is returned; otherwise history is not returned.
+ *   bool include_history = 4;
+ * }
+ *
+ * // Response from User::Status rpc.
+ * message UserStatusResponse {
+ *   // Standard RPC response header.
+ *   ResponseHeader header = 1;
+ *
+ *   // Unique identifier of the user.
+ *   Identifier user_id = 2;
+ *
+ *   // Authority identifier of the user.
+ *   // Maximum size for a user authority identifier is 2048 bytes (2 KiB).
+ *   string authority_id = 3;
+ *
+ *   // Name of the user.
+ *   // Maximum size for a user name is 1024 bytes (1 KiB).
+ *   string username = 4;
+ *
+ *   // Timestamp the user account was created.
+ *   Timestamp created = 5;
+ *
+ *   // Timestamp the user last interacted with the system.
+ *   // No value will be provided if the user has never interacted with the system.
+ *   Timestamp last_access = 6;
+ *
+ *   // True if the user has the ability to set user account privileges; otherwise false.
+ *   bool is_administrator = 8;
+ *
+ *   // True if the user can read jobs they did not create; otherwise false.
+ *   bool can_read_jobs = 9;
+ *
+ *   // True if the user can create jobs; otherwise false.
+ *   bool can_create_jobs = 10;
+ *
+ *   // True if the user can delete jobs; otherwise false.
+ *   bool can_delete_jobs = 11;
+ *
+ *   // True if the user can create (aka register) new MONAI application packages; otherwise false.
+ *   bool can_create_maps = 13;
+ *
+ *   // True if the user can delete (aka disable) know MONAI application packages; otherwise false.
+ *   bool can_delete_maps = 14;
+ *
+ *   // True if the user can list and download from payloads they did not create; otherwise false.
+ *   bool can_read_payloads = 15;
+ *
+ *   // True if the user can create payloads; othersise false.
+ *   bool can_create_payloads = 16;
+ *
+ *   // True if the user can delete payloads they did not create; otherwise false.
+ *   bool can_delete_payloads = 17;
+ *
+ *   // History of the user account.
+ *   // This is only the history of the account, and does not include any user action history.
+ *   // Only provided when include_history = true.
+ *   repeated HistoricalEvent history = 24;
+ * }
+**/


### PR DESCRIPTION
This commit adds the initial version of the MONAID Server API (GRPC based).

Some elements of the API are marked as "Feature Not Available in Current Version". These items are planned for future versions of the Server.

The goal of this pull-request is to spark discussion about the features provided by MONAI Deploy Application Server.

I recommend starting with `map.proto` file.