### PR TITLE
Add the mention of env var of MONAI_MODELPATH and its default in the package spec

### DIFF
--- a/guidelines/monai-application-package.md
+++ b/guidelines/monai-application-package.md
@@ -421,6 +421,12 @@ The Executor SHOULD provide a customized set of environment variables and comman
 
     - When not provided the default path `/var/monai/` SHALL be assumed.
 
+  - `MONAI_MODELPATH`: The Application's working directory (default: `/opt/monai/models/`).
+
+    - The value provided must be an absolute path (first character is `/`).
+
+    - When not provided the default path `/opt/monai/models/` SHALL be assumed.
+
 #### Table of Environment Variables
 
 | Variable            | Default                                    | Format              | Description                                      |
@@ -433,6 +439,7 @@ The Executor SHOULD provide a customized set of environment variables and comman
 | `MONAI_OUTPUTPATH`  | `/var/monai/output/`                       | Folder Path         | Path to the output folder for the Application.   |
 | `MONAI_TIMEOUT`     | `/etc/monai/app.json#timeout`              | Integer             | Timeout, in seconds, applied to the Application. |
 | `MONAI_WORKDIR`     | `/var/monai/`                              | Folder Path         | Path to the Application's working directory.     |
+| `MONAI_MODELPATH`   | `/opt/monai/models/`                       | Folder Path         | Path to the Application's models directory.     |
 
 
 ### Manifest Export


### PR DESCRIPTION
Need to explicitly add the definition of the important env var MONAI_MODELPATH and its default. There had no good reasons why this var was not in the spec in the first place.
- there was to be an `executor` module, in fact .Net assembly, in a MONAI App Package container, which acts as the entrypoint to ensure all folders are mapped correctly, and corresponding env var set accordingly. The `executor` entrypoint was supposed to be used by `MONAI App Server` "behind the scene". The `App Server`, however, was abandoned, and the `executor` not called by other hosting agents, e.g. Argo or Docker Compose.
- Have to make this env var explicitly known so that any scripts/service launch the MAP container knows its existence. 
- A separate issue is with the App SDK packager, for unknown reason, did not set this var in the container image. This will be fixed in App SDK.

Signed-off-by: M Q <mingmelvinq@nvidia.com>